### PR TITLE
[1.0] DUNE: adds passing arguments to programs (CMake, gdb, and ctest)

### DIFF
--- a/src/dune/__main__.py
+++ b/src/dune/__main__.py
@@ -90,22 +90,13 @@ if __name__ == '__main__':
             dune_sys.init_project(args.create_bare_app[0], dune_sys._docker.abs_host_path(args.create_bare_app[1]), False)
 
          elif args.cmake_build != None:
-            if len(args.cmake_build) > 1:
-               dune_sys.build_cmake_proj(args.cmake_build[0], parse_optional(args.cmake_build[1]))
-            else:
-               dune_sys.build_cmake_proj(args.cmake_build[0], [])
+            dune_sys.build_cmake_proj(args.cmake_build[0], parse_optional(args.remainder))
 
          elif args.ctest != None:
-            if len(args.ctest) > 1:
-               dune_sys.ctest_runner(args.ctest[0], parse_optional(args.ctest[1]))
-            else:
-               dune_sys.ctest_runner(args.ctest[0], [])
+            dune_sys.ctest_runner(args.ctest[0], parse_optional(args.remainder))
          
          elif args.gdb != None:
-            if len(args.gdb) > 1:
-               dune_sys.gdb(args.gdb[0], parse_optional(args.gdb[1]))
-            else:
-               dune_sys.gdb(args.gdb[0], [])
+            dune_sys.gdb(args.gdb[0], parse_optional(args.remainder))
 
          elif args.deploy != None:
             dune_sys.deploy_contract(dune_sys._docker.abs_host_path(args.deploy[0]), args.deploy[1])

--- a/src/dune/args.py
+++ b/src/dune/args.py
@@ -36,8 +36,10 @@ def fix_args(args):
    return arg_list
 
 def parse_optional(cmd):
-   cmd = cmd[1:-1] # remove containing []
-   return cmd.split()
+   if cmd is not None:
+      return cmd[1:] # remove leading --
+   else:
+      return cmd # empty list
 class arg_parser:
    def __init__(self):
       self._parser = argparse.ArgumentParser(description='DUNE: Docker Utilities for Node Execution')
@@ -58,9 +60,9 @@ class arg_parser:
       self._parser.add_argument('--create-account', nargs='+', metavar=["NAME","CREATOR (Optional)", "PUB_KEY (Optional)", "PRIV_KEY (Optional)"], help='create an EOSIO account and an optional creator (the default is eosio)')
       self._parser.add_argument('--create-cmake-app', nargs=2, metavar=["PROJ_NAME", "DIR"], help='create a smart contract project at from a specific host location')
       self._parser.add_argument('--create-bare-app', nargs=2, metavar=["PROJ_NAME", "DIR"], help='create a smart contract project at from a specific host location')
-      self._parser.add_argument('--cmake-build', nargs='+', metavar=["DIR", "FLAGS (Optional)"], help='build a smart contract project at the directory given optional flags are of the form [-DFLAG1=On -DFLAG2=Off]')
-      self._parser.add_argument('--ctest', nargs='+', metavar=["DIR", "FLAGS (Optional)"], help='run the ctest tests for a smart contract project at the directory given optional flags are of the form [-VV]')
-      self._parser.add_argument('--gdb', nargs='+', metavar=["DIR", "FLAGS (Optional)"], help='run the ctest tests for a smart contract project at the directory given optional flags are of the form [-VV]')
+      self._parser.add_argument('--cmake-build', nargs=1, metavar=["DIR", "-- FLAGS (Optional)"], help='build a smart contract project at the directory given optional flags are of the form -- -DFLAG1=On -DFLAG2=Off]')
+      self._parser.add_argument('--ctest', nargs=1, metavar=["DIR", "-- FLAGS (Optional)"], help='run the ctest tests for a smart contract project at the directory given optional flags are of the form -- -VV')
+      self._parser.add_argument('--gdb', nargs=1, metavar=["DIR", "-- FLAGS (Optional)"], help='run the ctest tests for a smart contract project at the directory given optional flags are of the form -- -VV')
       self._parser.add_argument('--deploy', nargs=2, metavar=["DIR", "ACCOUNT"], help='deploy a smart contract and ABI to account given')
       self._parser.add_argument('--destroy-container', action='store_true', help='destroy context container <Warning, this will destroy your state and block log>')
       self._parser.add_argument('--stop-container', action='store_true', help='stop the context container')
@@ -74,6 +76,7 @@ class arg_parser:
       self._parser.add_argument('--get-table', nargs=3, metavar=["ACCOUNT", "SCOPE", "TABLE"], help='get the data from the given table')
       self._parser.add_argument('--activate-feature', metavar=["CODENAME"], help='active protocol feature')
       self._parser.add_argument('--list-features', action='store_true', help='list available protocol feature code names')
+      self._parser.add_argument('remainder', nargs=argparse.REMAINDER) # used to store arguments to individual programs, starting with --
       #TODO readdress after the launch
       #self._parser.add_argument('--start-webapp', metavar=["DIR"], help='start a webapp with ')
    


### PR DESCRIPTION
Resolved https://github.com/eosnetworkfoundation/DUNE/issues/10.

Arguments of programs like CMake, gdb, and ctest are introduced using --, after DUNE's own arguments.

A section of DUNE's help look like

...
dune -h
  --cmake-build ['DIR', '-- FLAGS (Optional)']
                        build a smart contract project at the directory given
                        optional flags are of the form -- -DFLAG1=On
                        -DFLAG2=Off]
  --ctest ['DIR', '-- FLAGS (Optional)']
                        run the ctest tests for a smart contract project at
                        the directory given optional flags are of the form --
                        -VV
  --gdb ['DIR', '-- FLAGS (Optional)']
                        run the ctest tests for a smart contract project at
                        the directory given optional flags are of the form --
                        -VV
...

A sample run of gdb with argument -c core-file looks like

dune --gdb ./src -- -c core-file
GNU gdb (Ubuntu 9.2-0ubuntu1~20.04.1) 9.2
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
/host/home/lh/work/dune/src: No such file or directory.
/app/core-file: No such file or directory.