### PR TITLE
adding message for wrong dune command

### DIFF
--- a/src/dune/__main__.py
+++ b/src/dune/__main__.py
@@ -132,6 +132,9 @@ if __name__ == '__main__':
          elif args.version:
             print ("DUNE "+version_full())
 
+         else
+            print("Unsupported or wrong command")
+
       except KeyboardInterrupt:
          pass
       except dune_node_not_found as err:

--- a/src/dune/__main__.py
+++ b/src/dune/__main__.py
@@ -132,7 +132,7 @@ if __name__ == '__main__':
          elif args.version:
             print ("DUNE "+version_full())
 
-         else
+         else:
             print("Unsupported or wrong command")
 
       except KeyboardInterrupt:


### PR DESCRIPTION
Sometime I mistakenly type docker command options after dune command and realise it later because dune is shutting its mouth. 
Yeah, trivial improvement for careless devs. :)